### PR TITLE
DP-6020 - Add total_results to response if results were truncated

### DIFF
--- a/src/typeahead/downstream.py
+++ b/src/typeahead/downstream.py
@@ -90,6 +90,7 @@ class Typeahead(SearchEndpoint):
                     if 'content' in r:
                         if len(r['content']) > 0:
                             if len(r['content']) > self.max_results:
+                                r['total_results'] = len(r['content'])
                                 r['content'] = r['content'][:self.max_results]
                             results.append(r)
         return results


### PR DESCRIPTION
This will solve the problem for the bag related typeahead services that
are truncated in the typeahead service itself. If this was already done
it should be  done the the original typeahead service for that specific
type