### PR TITLE
Fix the dockerimage for CI testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amsterdam/python
+FROM amsterdam/python:3.7-buster
     WORKDIR /root/app
     COPY . /root/app/
     RUN pip install .

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM amsterdam/python
+FROM amsterdam/python:3.7-buster
     RUN apt-get update
     RUN apt-get install make
     WORKDIR /root/app


### PR DESCRIPTION
The amsterdam/python base image is based on debian stretch, however, the `apt-get update` fails, because the debian stretch apt release files seem to have been removed.

Also the base image for the typeahead application has been changed.